### PR TITLE
Also respect subclasses / subinterfaces for natively supported comparators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Deep Java object comparison (without the need to implement equals)
           }));
   ```
 
-* it also natively supports:
+* it also natively supports (including all subinterfaces and -classes):
   * `Optional`: deep compares the contained objects recursively when appropriate.
   * `Map`: maps must contain the same keys. Values are deep compared.
   * `Set`: must contain the same elements as indicated by `equals` and `hashCode`. No deep comparison takes place.
-  * `List`, arrays, `Collection`, and `Iterable`: deep compares the elements. Choice of strict or lenient ordering.
+  * arrays and `Iterable`: deep compares the elements. Choice of strict or lenient ordering.
   
 * supports overriding the way types/properties are compared.
 * by default is expects all types involved to be data-carrying objects exclusively i.e. all methods on the objects in the tree both take no args and return something. This restriction can be relaxed, though:

--- a/src/main/java/deepequals/DeepEquals.java
+++ b/src/main/java/deepequals/DeepEquals.java
@@ -209,13 +209,6 @@ public final class DeepEquals {
                     asList((Object[]) y));
         }
 
-        private boolean compareCollections(final TypeToken tt, final Object x, final Object y) {
-            return compareSequencesOf(
-                    getTypeArgToken(tt, 0),
-                    asList(((Collection<?>) x).toArray(new Object[] {})),
-                    asList(((Collection<?>) y).toArray(new Object[] {})));
-        }
-
         @SuppressWarnings("unchecked")
         private boolean compareDeep(final TypeToken tt, final Object x, final Object y) {
             final Set<Method> ms = methodsToInvoke(tt);
@@ -251,10 +244,6 @@ public final class DeepEquals {
                     getTypeArgToken(tt, 0),
                     Lists.newArrayList((Iterable<?>) x),
                     Lists.newArrayList((Iterable<?>) y));
-        }
-
-        private boolean compareLists(final TypeToken tt, final Object x, final Object y) {
-            return compareSequencesOf(getTypeArgToken(tt, 0), (List<?>) x, (List<?>) y);
         }
 
         private boolean compareMaps(final TypeToken tt, final Object x, final Object y) {
@@ -358,12 +347,6 @@ public final class DeepEquals {
             if (comparing(tt, Map.class)) {
                 return compareMaps(tt, x, y);
             }
-            if (comparing(tt, List.class)) {
-                return compareLists(tt, x, y);
-            }
-            if (comparing(tt, Collection.class)) {
-                return compareCollections(tt, x, y);
-            }
             if (comparing(tt, Iterable.class)) {
                 return compareIterables(tt, x, y);
             }
@@ -462,7 +445,7 @@ public final class DeepEquals {
         }
 
         private static boolean comparing(final TypeToken tt, final Class c) {
-            return tt.getRawType().equals(c);
+            return c.isAssignableFrom(tt.getRawType());
         }
 
         private static void enforceNoMethodsReturningVoid(

--- a/src/test/java/deepequals/test/DeepEqualsTest.java
+++ b/src/test/java/deepequals/test/DeepEqualsTest.java
@@ -226,6 +226,28 @@ class DeepEqualsTest {
                 ImmutableList.of(2, 1)));
     }
 
+    @Test
+    void compareSubclassOfIterable() {
+        class Foo {
+            final ImmutableList<String> bar;
+
+            public Foo (List<String> bar) {
+                this.bar = ImmutableList.copyOf(bar);
+            }
+
+            public ImmutableList<String> getBar() {
+                return bar;
+            }
+        }
+
+        Foo control = new Foo(Arrays.asList("x", "y"));
+        Foo test = new Foo(Arrays.asList("x", "y"));
+
+        assertTrue(deepEquals(Foo.class, control, test));
+    }
+
+
+
     @SuppressWarnings("serial")
     @Test
     void _11_orderLenient() {


### PR DESCRIPTION
First of all, many thanks for providing this library, it is exactly what I was looking for. :+1:

I had an Issue when comparing classes that returned ImmutableLists, e.g.:

```java
@Test
    void compareSubclassOfIterable() {
        class Foo {
            final ImmutableList<String> bar;

            public Foo (List<String> bar) {
                this.bar = ImmutableList.copyOf(bar);
            }

            public ImmutableList<String> getBar() {
                return bar;
            }
        }

        Foo control = new Foo(Arrays.asList("x", "y"));
        Foo test = new Foo(Arrays.asList("x", "y"));

        assertTrue(withOptions().typeLenient().deepEquals(Foo.class, control, test));
    }
```

Contrary to what I had expected, it did not use the implementation for lists, but issued this error:
```
deepequals.CycleException: cycle starts at index: 2
0: deepequals.test.DeepEqualsTest$3Foo::getBar
1: java.util.Collection::stream
2: java.util.stream.Stream::sorted
```

The cause is that the deepequals.DeepEquals.Stateful#comparing method only checks if the types are equals, but not if the given type is a subclass or subinterface:
```java
return tt.getRawType().equals(c);
```

My suggestion is to use this code instead:
```java
return c.isAssignableFrom(tt.getRawType());
```

A positive side effect is that it makes `compareLists` and `compareCollections` obsolete as the both inherit from `Iterable`.